### PR TITLE
chore: wrap `useChat.handleInputChange` in `useCallback`

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -550,9 +550,13 @@ By default, it's set to 1, which means that only a single LLM call is made.
     [input, generateId, triggerRequest],
   );
 
-  const handleInputChange = (e: any) => {
-    setInput(e.target.value);
-  };
+  const handleInputChange = useCallback(
+    (e: any) => {
+      setInput(e.target.value);
+    },
+    [setInput]
+  );
+    
 
   const addToolResult = useCallback(
     ({ toolCallId, result }: { toolCallId: string; result: unknown }) => {


### PR DESCRIPTION
## Background
Missing useCallback here lead to unnecessary re-renders, in the consumer of `useChat`.

## Summary

Added useCallback to `handleInputChange`

## Verification

Not done.

## Related Issues

Fixes #6266
